### PR TITLE
Add Douyin datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Development and Build artefacts
+.idea

--- a/manifest.json
+++ b/manifest.json
@@ -40,7 +40,8 @@
       "modules/parler.js",
       "modules/9gag.js",
       "modules/imgur.js",
-      "modules/twitter.js"
+      "modules/twitter.js",
+      "modules/douyin.js"
     ]
   }
 }

--- a/modules/douyin.js
+++ b/modules/douyin.js
@@ -59,17 +59,28 @@ zeeschuimer.register_module(
                 } else if (search_result["card_unique_name"] === "aweme_mix") {
                     // Collection of videos
                     let mix_videos = search_result["aweme_mix_info"]["mix_items"];
+                    let first_mix_vid = true;
                     for(let j in mix_videos) {
                         // Each video has mix_info data
                         // item_data["mix_info"]["statis"]["current_episode"] is an int starting at 1 representing the video order
                         let item_data = mix_videos[j];
                         item_data["id"] = item_data["aweme_id"];
+                        // Add some metadata to ensure we know video was found in mix and which video was displayed (i.e. the first)
+                        item_data["ZS_collected_from_mix"] = true;
+                        if (first_mix_vid) {
+                            // We know this video was displayed on screen
+                            item_data["ZS_first_mix_vid"] = true;
+                            first_mix_vid = false;
+                        } else {
+                            item_data["ZS_first_mix_vid"] = false;
+                        }
                         usable_items.push(item_data);
                         mix_video_count++;
                     }
                     mix_count++;
-                } else if (search_result["card_unique_name"] === "baike_wiki_doc") {
-                    // These are cool chinese wiki cards; I have seen them explaining the search term used
+                } else if (["baike_wiki_doc", "douyin_trending"].includes(search_result["card_unique_name"])) {
+                    // baike_wiki_doc are cool chinese wiki cards; I have seen them explaining the search term used
+                    // douyin_trending trending data
                 } else {
                         console.log("WARNING: NEW card type detected! Notify ZeeSchuimer developers https://github.com/digitalmethodsinitiative/zeeschuimer/issues")
                         console.log(search_result)

--- a/modules/douyin.js
+++ b/modules/douyin.js
@@ -37,6 +37,11 @@ zeeschuimer.register_module(
             for(let i in data["aweme_list"]) {
                 let item_data = data["aweme_list"][i];
                 item_data["id"] = item_data["aweme_id"];
+                // On search page, items collected this way are part of collections/mixes and not the first video
+                if (source_platform_url.includes("douyin.com/search")) {
+                    item_data["ZS_collected_from_mix"] = true;
+                    item_data["ZS_first_mix_vid"] = false;
+                }
                 usable_items.push(item_data);
             }
             console.log(`Collected ${usable_items.length} Douyin videos downloaded`)

--- a/modules/douyin.js
+++ b/modules/douyin.js
@@ -4,7 +4,7 @@ zeeschuimer.register_module(
     function (response, source_platform_url, source_url) {
         let domain = source_platform_url.split("/")[2].toLowerCase().replace(/^www\./, '');
 
-        if (!["douyin.com"].includes(domain)) {
+        if (domain !== 'douyin.com' && domain !== 'live.douyin.com') { //!["douyin.com", "live.douyin.com"].includes(domain)) {
             return [];
         }
 
@@ -15,21 +15,47 @@ zeeschuimer.register_module(
             return [];
         }
 
+        if (("e" in data) && ("sc" in data) && ("tc" in data) && (3 === Object.keys(data).length)) {
+            // These appear to be status pings of some kind
+            return [];
+        } else {
+            // debug
+            console.log("MAYBE INTERESTING")
+            console.log(data)
+        }
+
         if ("cards" in data) {
+            // Front Page (首页) tab
             console.log("Collecting Douyin Front Page data...")
-            let useable_items = [];
+            let usable_items = [];
             for(let i in data["cards"]) {
                 let item = data["cards"][i]["aweme"];
                 try {
                     let item_data = JSON.parse(item);
                     item_data["id"] = item_data["aweme_id"];
-                    useable_items.push(item_data);
+                    usable_items.push(item_data);
                 } catch (SyntaxError) {
                     console.log("Failed to parse item: " + item)
                 }
 
             }
-            return useable_items;
+            return usable_items;
         }
+
+        // Recommend (推荐) tab, Hot (热点) tab, and Channels (e.g. game (游戏), entertainment (娱乐), music (音乐))
+        if ("aweme_list" in data) {
+            console.log("Collecting Douyin Recommend, Hot, or Channel data...")
+            let usable_items = [];
+            for(let i in data["aweme_list"]) {
+                let item_data = data["aweme_list"][i];
+                item_data["id"] = item_data["aweme_id"];
+                usable_items.push(item_data);
+            }
+            return usable_items;
+        }
+
+        // if () {
+        //     // Live Stream (直播) tab}
+        // }
     }
 );

--- a/modules/douyin.js
+++ b/modules/douyin.js
@@ -1,0 +1,35 @@
+zeeschuimer.register_module(
+    'Douyin',
+    'douyin.com',
+    function (response, source_platform_url, source_url) {
+        let domain = source_platform_url.split("/")[2].toLowerCase().replace(/^www\./, '');
+
+        if (!["douyin.com"].includes(domain)) {
+            return [];
+        }
+
+        let data;
+        try {
+            data = JSON.parse(response);
+        } catch (SyntaxError) {
+            return [];
+        }
+
+        if ("cards" in data) {
+            console.log("Collecting Douyin data...")
+            let useable_items = [];
+            for(let i in data["cards"]) {
+                let item = data["cards"][i]["aweme"];
+                try {
+                    let item_data = JSON.parse(item);
+                    item_data["id"] = item_data["aweme_id"];
+                    useable_items.push(item_data);
+                } catch (SyntaxError) {
+                    console.log("Failed to parse item: " + item)
+                }
+
+            }
+            return useable_items;
+        }
+    }
+);

--- a/modules/douyin.js
+++ b/modules/douyin.js
@@ -16,7 +16,7 @@ zeeschuimer.register_module(
         }
 
         if ("cards" in data) {
-            console.log("Collecting Douyin data...")
+            console.log("Collecting Douyin Front Page data...")
             let useable_items = [];
             for(let i in data["cards"]) {
                 let item = data["cards"][i]["aweme"];

--- a/modules/douyin.js
+++ b/modules/douyin.js
@@ -3,8 +3,7 @@ zeeschuimer.register_module(
     'douyin.com',
     function (response, source_platform_url, source_url) {
         let domain = source_platform_url.split("/")[2].toLowerCase().replace(/^www\./, '');
-
-        if (domain !== 'douyin.com' && domain !== 'live.douyin.com') { //!["douyin.com", "live.douyin.com"].includes(domain)) {
+        if (!["douyin.com"].includes(domain)) {
             return [];
         }
 
@@ -18,15 +17,8 @@ zeeschuimer.register_module(
         if (("e" in data) && ("sc" in data) && ("tc" in data) && (3 === Object.keys(data).length)) {
             // These appear to be status pings of some kind
             return [];
-        } else {
-            // debug
-            console.log("MAYBE INTERESTING")
-            console.log(data)
-        }
-
-        if ("cards" in data) {
+        } else if ("cards" in data) {
             // Front Page (首页) tab
-            console.log("Collecting Douyin Front Page data...")
             let usable_items = [];
             for(let i in data["cards"]) {
                 let item = data["cards"][i]["aweme"];
@@ -39,23 +31,28 @@ zeeschuimer.register_module(
                 }
 
             }
+            console.log(`Collected ${usable_items.length} Douyin videos from Front page tab`)
             return usable_items;
-        }
+        } else if ("aweme_list" in data) {
+            // Recommend (推荐) tab, Hot (热点) tab, and Channels (e.g. game (游戏), entertainment (娱乐), music (音乐))
 
-        // Recommend (推荐) tab, Hot (热点) tab, and Channels (e.g. game (游戏), entertainment (娱乐), music (音乐))
-        if ("aweme_list" in data) {
-            console.log("Collecting Douyin Recommend, Hot, or Channel data...")
             let usable_items = [];
             for(let i in data["aweme_list"]) {
                 let item_data = data["aweme_list"][i];
                 item_data["id"] = item_data["aweme_id"];
                 usable_items.push(item_data);
             }
+            console.log(`Collected ${usable_items.length} Douyin videos from Recommend, Hot, or Channel tabs`)
             return usable_items;
+        } else {
+            // debug
+            //console.log("MAYBE INTERESTING")
+            //console.log(data)
         }
 
         // if () {
         //     // Live Stream (直播) tab}
+        // Unable to detect this domain?
         // }
     }
 );


### PR DESCRIPTION
Works for home page, discover page, recommend page, and various channel pages. It does not work for live.douyin.com and I have not the foggiest reason as to why. It's almost as if it doesn't get to the module...

Data from the various sources does seem to differ so any 4CAT datasource processor will need to use the `source_platform_url` to parse appropriately. I believe that's how we'd prefer to handle this.