### PR TITLE
Distinguish "promoted" tweets in Twitter

### DIFF
--- a/modules/twitter.js
+++ b/modules/twitter.js
@@ -65,6 +65,10 @@ zeeschuimer.register_module(
                                 tweet = tweet['tweet'];
                             }
                             tweet['id'] = tweet['legacy']['id_str'];
+                            // distinguish tweets that were included because they were "promoted" from
+                            // those that are actually part of the user/home timeline or search result.
+                            // assume a tweet was promoted if itemContent has promotedMetadata
+                            tweet['promoted'] = ('promotedMetadata' in entry['content']['itemContent']);
                             tweets.push(tweet);
 
                         } else {


### PR DESCRIPTION
Adds a `promoted` property to the JSON generated for a collected tweet, which is `true` if the tweet was "promoted" by Twitter (i.e. an advert inserted into the middle of a stream of search results or timeline tweets) or `false` if the tweet is a genuine search result or timeline item.  This makes it possible to filter out the promoted adverts from the collected data and work just with tweets that actually matched your search terms.

Fixes #16