### PR TITLE
capture tweets when viewing a given post and not logged in

### DIFF
--- a/modules/twitter.js
+++ b/modules/twitter.js
@@ -16,6 +16,7 @@ zeeschuimer.register_module(
                 && source_url.indexOf('Likes') < 0
                 && source_url.indexOf('SearchTimeline') < 0
                 && source_url.indexOf('TweetDetail') < 0
+                && source_url.indexOf('TweetResultByRestId') < 0
                 // this one is not enabled because it is always loaded when viewing a user profile
                 // even when not viewing the media tab
                 // && source_url.indexOf('UserMedia') < 0
@@ -116,6 +117,12 @@ zeeschuimer.register_module(
                         }
                     }
 
+                } else if (child.hasOwnProperty('__typename') &&  child['__typename'] === "Tweet") {
+                    // this only fires when we hit the TweetResultByRestId endpoint, and that only happens
+                    // when the user views a post without being logged in, in which case it doesn't
+                    // load all the replies so the normal endpoints aren't used.
+                    child["id"] = child['legacy']['id_str'];
+                    tweets.push(child);
                 } else if (typeof (child) === "object") {
                     traverse(child);
                 }


### PR DESCRIPTION
If you visit the URL of an individual tweet (i.e. a url of the form `https://x.com/<account>/status/<post id>`) when not logged then the tweet is not currently captured by the plugin.

It appears that when not logged in a different endpoint `TweetResultByRestId` is used and this PR adds support for this endpoint to the twitter module.